### PR TITLE
Add SQL script to create initial admin user

### DIFF
--- a/setup-admin.sql
+++ b/setup-admin.sql
@@ -1,0 +1,67 @@
+-- Create your first admin account
+-- Replace YOUR_EMAIL and YOUR_PASSWORD with actual values
+
+DO $$
+DECLARE
+    user_id uuid;
+BEGIN
+    -- Create auth user
+    INSERT INTO auth.users (
+        instance_id,
+        id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        recovery_sent_at,
+        last_sign_in_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        email_change,
+        email_change_token_new,
+        recovery_token
+    ) VALUES (
+        '00000000-0000-0000-0000-000000000000',
+        gen_random_uuid(),
+        'authenticated',
+        'authenticated',
+        'YOUR_EMAIL@example.com', -- CHANGE THIS
+        crypt('YOUR_PASSWORD', gen_salt('bf')), -- CHANGE THIS
+        now(),
+        null,
+        now(),
+        '{"provider":"email","providers":["email"]}',
+        '{}',
+        now(),
+        now(),
+        '',
+        '',
+        '',
+        ''
+    ) RETURNING id INTO user_id;
+
+    -- Create user profile with admin role
+    INSERT INTO user_profiles (
+        id,
+        email,
+        role,
+        status,
+        display_name,
+        created_at,
+        updated_at
+    ) VALUES (
+        user_id,
+        'YOUR_EMAIL@example.com', -- CHANGE THIS
+        'Admin',
+        'active',
+        'Admin User', -- CHANGE THIS
+        now(),
+        now()
+    );
+
+    RAISE NOTICE 'Admin user created with ID: %', user_id;
+END $$;


### PR DESCRIPTION
## Summary
- Adds a new SQL script `setup-admin.sql` to create the first admin account in the database
- Script inserts a user into `auth.users` and a corresponding profile in `user_profiles` with admin role
- Requires replacing placeholder email and password values with actual credentials

## Changes

### Database Setup
- **setup-admin.sql**: New SQL script that:
  - Creates an authenticated user with encrypted password
  - Inserts a user profile with role `Admin` and status `active`
  - Uses a PL/pgSQL block to handle user creation and returns the new user ID

## Usage
- Replace `YOUR_EMAIL@example.com` and `YOUR_PASSWORD` in the script with real admin credentials before running
- Run this script during initial deployment or setup to ensure an admin user exists

## Test plan
- [ ] Verify the script runs without errors on a fresh database
- [ ] Confirm the admin user is created with correct email and role
- [ ] Check that the password is stored encrypted
- [ ] Validate that the user profile is linked to the auth user and has admin privileges

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/abfaacf9-cac0-4f74-80e7-0992fd20b491