### PR TITLE
Potential fix for code scanning alert no. 8: Use of externally-controlled format string

### DIFF
--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -105,7 +105,7 @@ class MonitoringService {
       this.sendToExternalService('security', eventWithTimestamp)
     }
 
-    console.warn(`[SECURITY] ${event.type}: IP ${event.ip}`, event.context)
+    console.warn('[SECURITY] %s: IP %s', event.type, event.ip, event.context)
   }
 
   // Get recent metrics


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/8](https://github.com/miketui/v0-appmain2/security/code-scanning/8)

The safest remedy is to ensure untrusted values do not get interpreted as format specifiers. Instead of building the log message with direct interpolation, use a static format string and supply user-provided values as arguments to `console.warn`, so Node.js treats them as data, not format tokens. Specifically, in `trackSecurityEvent`, replace:
```ts
console.warn(`[SECURITY] ${event.type}: IP ${event.ip}`, event.context)
```
with:
```ts
console.warn('[SECURITY] %s: IP %s', event.type, event.ip, event.context)
```
This approach is resilient to malicious format specifiers, and the log will be correct even if an attacker tries to supply `%s`, `%d`, etc., as data. No imports or additional dependencies are necessary; only local replacement in `trackSecurityEvent` inside `lib/monitoring.ts` is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
