### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -168,6 +168,8 @@ jobs:
   database-migration:
     name: Run Database Migrations
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: deploy-staging
     if: github.ref == 'refs/heads/staging'
     


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/35](https://github.com/miketui/v0-appmain2/security/code-scanning/35)

To fix this, add a `permissions` block to the `database-migration` job in `.github/workflows/staging-deploy.yml` to limit the `GITHUB_TOKEN` permissions to the minimum required. Since this job only performs code checkout, installs dependencies, and runs commands using secrets for authentication (but doesn't push code, open issues, comment, etc.), it is safest to provide only `contents: read` permission (the minimal sensible default for jobs that use actions/checkout; if checkout with GITHUB_TOKEN is not needed, use `none`). 

The `permissions` block should be added at the same indentation as `runs-on` (i.e., directly under the job name). No other changes are needed to other jobs or the root workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
