### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete multi-character sanitization

### DIFF
--- a/src/tests/security/security.test.ts
+++ b/src/tests/security/security.test.ts
@@ -102,9 +102,13 @@ describe('Security Tests', () => {
       ]
 
       const sanitizeDisplayName = (input: string): string => {
-        // Basic sanitization - remove HTML tags and dangerous characters
+        // Improved: Remove HTML tags in a loop (handles multi-layer/multi-character tags)
+        let prev: string
+        do {
+          prev = input
+          input = input.replace(/<[^>]*>/g, '')
+        } while (input !== prev)
         return input
-          .replace(/<[^>]*>/g, '') // Remove HTML tags
           .replace(/(javascript:|data:|vbscript:)/gi, '') // Remove dangerous protocols
           .replace(/on\w+\s*=/gi, '') // Remove event handlers
           .trim()


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/10](https://github.com/miketui/v0-appmain2/security/code-scanning/10)

The best way to fix the problem is to ensure that the sanitization process is effective even against crafted inputs that can evade a single-pass regular expression replacement. The `replace(/<[^>]*>/g, '')` only removes the first layer of tags, potentially leaving behind further `<...>` substrings. To robustly remove all HTML tags, either a sanitization library should be used (preferable in real apps), or the replacement should be applied repeatedly until no more tags exist.

For the test context, we can patch the sanitizer by applying the tag-removal regex in a loop until there are no more matches (i.e., "repeat replacement until input stabilizes" strategy). This also applies to other `.replace()` sanitization calls for protocols/events, though most attacks rely on tag-based injection.

Only lines 106-112 in the shown function need to be changed in `src/tests/security/security.test.ts`:
- Refactor line 107 to use a loop to strip tags until none remain (repeatedly apply the regex).
- Optionally, ensure the protocol/event replacements are robust.

No imports are needed if a library is not required (unless we choose to use a well-known sanitizer npm package). For the scope given, since we can only change code we've seen, use an in-place loop as per the examples.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
