### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -83,7 +83,7 @@ class MonitoringService {
       this.sendToExternalService('error', errorWithTimestamp)
     }
 
-    console.error(`[ERROR] ${error.level.toUpperCase()}: ${error.message}`, error.context)
+    console.error('[ERROR] %s: %s', error.level.toUpperCase(), error.message, error.context)
   }
 
   // Track security events


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/7](https://github.com/miketui/v0-appmain2/security/code-scanning/7)

To fix the format string vulnerability, we should *not* interpolate user input directly into the log message format string. Instead, use a static format string and pass all user-controlled values as arguments. For example, instead of  
`console.error(`[ERROR] ${error.level.toUpperCase()}: ${error.message}`, error.context)`,  
use  
`console.error('[ERROR] %s: %s', error.level.toUpperCase(), error.message, error.context);`.

This ensures that any user-controlled content is only inserted in place of specifiers, never interpreted as specifiers, preventing misuse. Only the code in `lib/monitoring.ts` line 86 needs to be updated.

No new imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
