### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,9 @@ const nextConfig = {
       'localhost',
       'via.placeholder.com',
       // Add your Supabase storage domain
-      process.env.NEXT_PUBLIC_SUPABASE_URL?.replace('https://', '').replace('.supabase.co', '.supabase.co') || ''
+      process.env.NEXT_PUBLIC_SUPABASE_URL
+        ? process.env.NEXT_PUBLIC_SUPABASE_URL.replace(/^https?:\/\//, '').split('/')[0]
+        : ''
     ].filter(Boolean),
     formats: ['image/webp', 'image/avif'],
   },


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/5](https://github.com/miketui/v0-appmain2/security/code-scanning/5)

To fix the problem, first clarify the intended extraction of the domain. The code:
```js
process.env.NEXT_PUBLIC_SUPABASE_URL?.replace('https://', '').replace('.supabase.co', '.supabase.co') || ''
```
removes `https://` from the beginning of the URL and then attempts to replace `.supabase.co` with itself, which does nothing. Most likely, the intention was to extract the part of the domain that matches `*.supabase.co`. 

The best fix with minimal change and to preserve functionality is to extract the domain from the URL by removing the protocol prefix (`https://`) and, if needed, strip any trailing slashes or paths. Using URL parsing will be robust, but with the constraints (keeping within code snippets shown, importing only well-known libraries), we can improve the line to remove the redundant replace and instead only strip the `https://` if that's the intention. 

Alternatively, if the goal was to also remove the `.supabase.co` suffix, we would write `.replace('.supabase.co', '')`.

**Recommended change:**  
- Remove the redundant `.replace('.supabase.co', '.supabase.co')`.
- If only the protocol should be removed, use `.replace(/^https?:\/\//, '')`.
- If only the domain name is needed for `images.domains`, we may want to extract only the hostname using the URL constructor. This will require importing the standard `url` module (for Node.js). However, since only code in the snippet can be edited, we can use a regex solution for simplicity.

**Code changes:**  
- In `next.config.mjs`, line 17: change `.replace('.supabase.co', '.supabase.co')` to either nothing, or to a useful transformation, such as `.replace(/^https?:\/\//, '')`.
- If a trailing path exists, also remove it with `.split('/')[0]`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
