### PR TITLE
Potential fix for code scanning alert no. 44: Incomplete multi-character sanitization

### DIFF
--- a/lib/security.ts
+++ b/lib/security.ts
@@ -125,7 +125,7 @@ export function sanitizeDisplayName(input: string): string {
     // Remove dangerous protocols
     sanitized = sanitized.replace(/(javascript:|data:|vbscript:|about:|file:)/gi, '')
     // Remove event handlers
-    sanitized = sanitized.replace(/on\w+\s*=?\s*[^>\s]*/gi, '')
+    sanitized = sanitized.replace(/on\w+/gi, '')
     // Remove HTML entities that could be used for XSS
     sanitized = sanitized.replace(/&[#\w]+;/gi, '')
   } while (sanitized !== prev)


### PR DESCRIPTION
Potential fix for [https://github.com/miketui/v0-appmain2/security/code-scanning/44](https://github.com/miketui/v0-appmain2/security/code-scanning/44)

The best way to fix this issue is to ensure *all* possible event-handler attributes are robustly removed. The do-while loop already repeatedly applies the sanitization, but the regex `/on\w+\s*=?\s*[^>\s]*/gi` is problematic; it can miss standalone occurrences of "on" and is not comprehensive for all event attributes.

- **General Fix:** Either rewrite the regular expression to match just "on" followed by letters (event handler attributes), *or* use a library for HTML sanitization, but since this is display name sanitization (not HTML), a simple and effective approach is to remove all "on" followed by any letters, using `/on\w+/gi`.
- **Detailed Fix:** Replace line 128's regular expression with a safer one: `/on\w+/gi`, so that any "on" followed by event handler letters, such as "onclick" or "onmouseover", is always removed, resolving even those that appear standalone.
- **Files/regions/lines to change:** Only lines inside `lib/security.ts`, specifically the region in `sanitizeDisplayName` function around line 128.
- **Other requirements:** No new dependencies or imports required. No new helper methods needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
